### PR TITLE
Update BugSigDB_paper_to_curate.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/BugSigDB_paper_to_curate.yml
+++ b/.github/ISSUE_TEMPLATE/BugSigDB_paper_to_curate.yml
@@ -22,7 +22,7 @@ body:
       label: Pubmed ID
       description: Enter the Pubmed ID if it is available
       placeholder: A pubmed ID (digits only)
-    validation:
+    validations:
       required: false
   - type: input
     id: doi
@@ -30,7 +30,7 @@ body:
       label: The Digital Object Identifier (DOI)
       description: Enter the DOI
       placeholder: https://doi.org/xxxxx
-    validation:
+    validations:
       required: true
   - type: textarea
     id: first-author

--- a/.github/ISSUE_TEMPLATE/BugSigDB_paper_to_curate.yml
+++ b/.github/ISSUE_TEMPLATE/BugSigDB_paper_to_curate.yml
@@ -16,6 +16,22 @@ body:
       placeholder: ex. Characteristics of the intestinal flora in patients with peripheral neuropathy associated with type 2 diabetes
     validations:
       required: true
+  - type: input
+    id: pmid
+    attributes:
+      label: Pubmed ID
+      description: Enter the Pubmed ID if it is available
+      placeholder: A pubmed ID (digits only)
+    validation:
+      required: false
+  - type: input
+    id: doi
+    attributes:
+      label: The Digital Object Identifier (DOI)
+      description: Enter the DOI
+      placeholder: https://doi.org/xxxxx
+    validation:
+      required: true
   - type: textarea
     id: first-author
     attributes:


### PR DESCRIPTION
Adds two unique identifiers:
1. PMID, optional.
2. DOI, required.

The idea is to ensure that a computable unique identifier is attached to studies. While PMID may not be available, I cannot think of any source of literature that would enter the curation process that will not have a DOI. 

The DOI allows for automated metadata population, provides clear provenance for the curation (ie., the curation is based on information from a specific DOI), and is guaranteed to be available.