### PR TITLE
Add GitHub Action to look up study information by doi

### DIFF
--- a/.github/ISSUE_TEMPLATE/BugSigDB_doi.yml
+++ b/.github/ISSUE_TEMPLATE/BugSigDB_doi.yml
@@ -3,7 +3,7 @@ description: |
   File a study curation by DOI. Attempts to automatically fetch study
   information.
 title: "[Study]: New Curation"
-labels: ["bugsigdb", "curation"]
+labels: ["paper to curate"]
 projects: ["BugSigDB"]
 body:
   - type: markdown
@@ -11,7 +11,9 @@ body:
       value: |
         Thanks for submitting this study for curation!
         
-        When you submit this form, a GitHub Action will attempt to find the title, first author, year of publication, and PMID. If it fails, you can manually submit a study curation.
+        When you submit this form, a GitHub Action will attempt to find the
+        title, first author, year of publication, and PMID. If it fails, you
+        can manually submit a study curation.
   - type: input
     id: doi
     attributes:

--- a/.github/ISSUE_TEMPLATE/BugSigDB_doi.yml
+++ b/.github/ISSUE_TEMPLATE/BugSigDB_doi.yml
@@ -1,0 +1,33 @@
+name: BugSigDB study curation by DOI
+description: |
+  File a study curation by DOI. Attempts to automatically fetch study
+  information.
+title: "[Study]: New Curation"
+labels: ["bugsigdb", "curation"]
+projects: ["BugSigDB"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for submitting this study for curation!
+        
+        When you submit this form, a GitHub Action will attempt to find the title, first author, year of publication, and PMID. If it fails, you can manually submit a study curation.
+  - type: input
+    id: doi
+    attributes:
+      label: The Digital Object Identifier (DOI)
+      description: |
+        Enter the DOI or prefix and suffix. For example, if your DOI is
+        https://doi.org/10.1000/182, you may enter
+        "https://doi.org/10.1000/182" or "10.1000/182".
+      placeholder: https://doi.org/xxxxx
+    validations:
+      required: true
+  - type: checkboxes
+    id: code-of-conduct
+    attributes:
+      label: Code of Conduct Agreement
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/Bioconductor/bioc_coc_multilingual). 
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/workflows/curation.yml
+++ b/.github/workflows/curation.yml
@@ -1,0 +1,138 @@
+name: BugSigDB Cuation
+on:
+  issues:
+    types: [opened] 
+#  issues_comment:
+#    types: [created]
+
+jobs:
+
+  curation-comment:
+    permissions:
+      issues: write
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    container: bioconductor/bioconductor_docker:devel
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: Cache
+        id: cache
+        uses: actions/cache@v4
+        with:
+          path:
+            /usr/local/lib/R/site-library
+            /usr/local/lib/R/library
+          key: ${{ runner.os }}-bugsigdb-curation
+
+      - name: Install dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+         Rscript -e "install.packages(c('stringr', 'httr2'), repos = 'https://cloud.r-project.org', dependencies = c('Depends', 'Imports'))"
+
+      - name: Get DOI
+        id: get-doi
+        run: |
+          encodeQuotes <- function(s) {
+            s <- stringr::str_replace_all(s, "'", "&apos;")
+            s <- stringr::str_replace_all(s, '"', "&quot;")
+            s
+          }
+          
+          doi <- ""
+          comments <- stringr::str_split("${{ github.event.issue.body }}", "\n", simplify = TRUE)
+          for (comment in comments) {
+            if (stringr::str_detect(comment, "[0-9.]+/[A-Za-z0-9.-]+")) {
+              doi <- comment
+              break
+            }  
+          }
+
+          crossref <- paste("https://api.crossref.org/works", doi, sep = "/")
+          cr <- httr2::request(crossref) |>
+            httr2::req_perform() |>
+            httr2::resp_body_json(simplifyVector = TRUE)
+
+          title <- ifelse("title" %in% names(cr$message),
+            encodeQuotes(cr$message$title),
+            "")
+
+          year <- ifelse("published" %in% names(cr$message),
+            cr$message$published$`date-parts`[1],
+            "")
+
+          journal <- ifelse("container-title" %in% names(cr$message),
+            encodeQuotes(cr$message$`container-title`[[1]]),
+            "")
+
+          author <- ""
+          if ('author' %in% names(cr$message)) {
+            author <- paste(encodeQuotes(cr$message$author$given[1]),
+                            encodeQuotes(cr$message$author$family[1]),
+                            sep = " ")
+          }
+
+          source <- ifelse("resource" %in% names(cr$message),
+                           encodeQuotes(cr$message$resource$primary$URL),
+                           "")
+          
+          eutils <- paste0("https://eutils.ncbi.nlm.nih.gov/entrez/eutils/",
+                           "esearch.fcgi?db=pubmed&term=",
+                           doi, "[DOI]&retmode=json")
+          
+          er <- httr2::request(eutils) |>
+            httr2::req_perform() |>
+            httr2::resp_body_json(simplifyVector = TRUE)
+          
+          pmid <- er$esearchresult$idlist
+          system(paste0("echo DOI='", doi, "' >> $GITHUB_OUTPUT"))
+          system(paste0("echo AUTHOR='", author, "' >> $GITHUB_OUTPUT"))
+          system(paste0("echo TITLE='", title, "' >> $GITHUB_OUTPUT"))
+          system(paste0("echo JOURNAL='", journal, "' >> $GITHUB_OUTPUT"))
+          system(paste0("echo YEAR=", year, " >> $GITHUB_OUTPUT"))
+          system(paste0("echo PMID=", pmid, " >> $GITHUB_OUTPUT"))
+          print(paste("DOI:", doi))
+          print(paste("PMID:", pmid))
+          print(paste("TITLE:", title))
+          print(paste("AUTHOR:", author))
+          print(paste("JOURNAL:", journal))
+          print(paste("YEAR:", year))
+        shell: Rscript {0}
+
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.update({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: "[Study]: ${{ steps.get-doi.outputs.TITLE }}"
+            })
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 
+              `
+              ### Study
+              ${{ steps.get-doi.outputs.TITLE }}
+
+              ### DOI
+              ${{ steps.get-doi.outputs.DOI }}
+
+              ### PMID
+              ${{ steps.get-doi.outputs.PMID }}
+
+              ### Author
+              ${{ steps.get-doi.outputs.AUTHOR }}
+
+              ### Journal
+              ${{ steps.get-doi.outputs.JOURNAL }}
+
+              ### Year
+              ${{ steps.get-doi.outputs.YEAR }}
+
+              👋 Thanks for submitting!
+              `
+            })

--- a/.github/workflows/curation.yml
+++ b/.github/workflows/curation.yml
@@ -98,6 +98,7 @@ jobs:
         shell: Rscript {0}
 
       - uses: actions/github-script@v7
+        if: steps.get-doi.outputs.DOI != ''
         with:
           script: |
             github.rest.issues.update({

--- a/.github/workflows/curation.yml
+++ b/.github/workflows/curation.yml
@@ -1,9 +1,7 @@
-name: BugSigDB Cuation
+name: Data for BugSigDB Curation by DOI
 on:
   issues:
     types: [opened] 
-#  issues_comment:
-#    types: [created]
 
 jobs:
 
@@ -113,7 +111,7 @@ jobs:
               repo: context.repo.repo,
               body: 
               `
-              ### Study
+              ### Title
               ${{ steps.get-doi.outputs.TITLE }}
 
               ### DOI

--- a/.github/workflows/curation.yml
+++ b/.github/workflows/curation.yml
@@ -21,7 +21,7 @@ jobs:
         id: cache
         uses: actions/cache@v4
         with:
-          path:
+          path: |
             /usr/local/lib/R/site-library
             /usr/local/lib/R/library
           key: ${{ runner.os }}-bugsigdb-curation
@@ -86,18 +86,15 @@ jobs:
             httr2::resp_body_json(simplifyVector = TRUE)
           
           pmid <- er$esearchresult$idlist
+
           system(paste0("echo DOI='", doi, "' >> $GITHUB_OUTPUT"))
           system(paste0("echo AUTHOR='", author, "' >> $GITHUB_OUTPUT"))
           system(paste0("echo TITLE='", title, "' >> $GITHUB_OUTPUT"))
           system(paste0("echo JOURNAL='", journal, "' >> $GITHUB_OUTPUT"))
           system(paste0("echo YEAR=", year, " >> $GITHUB_OUTPUT"))
           system(paste0("echo PMID=", pmid, " >> $GITHUB_OUTPUT"))
-          print(paste("DOI:", doi))
-          print(paste("PMID:", pmid))
-          print(paste("TITLE:", title))
-          print(paste("AUTHOR:", author))
-          print(paste("JOURNAL:", journal))
-          print(paste("YEAR:", year))
+
+          print(paste("DOI:", doi, "PMID:", pmid, "TITLE:", title, "AUTHOR:", author, "JOURNAL:", journal, "YEAR:", year))
         shell: Rscript {0}
 
       - uses: actions/github-script@v7


### PR DESCRIPTION
This adds a Github Action to look up study name, pubmed id, publication year, and first author given a doi in an issue by making a comment on that issue. I made a minimal version of Svetlana's template that just asks for the doi to add some instructions on its use. You can see how this works by looking at https://github.com/jwokaty/BugSigDBcuration/issues.

Example with the comment: https://github.com/jwokaty/BugSigDBcuration/issues/25
DOI template: https://github.com/jwokaty/BugSigDBcuration/issues/new?template=BugSigDB_doi.yml

Close #625 